### PR TITLE
fix: fixed some errors with FreeRTOSTimer class

### DIFF
--- a/include/ot_utils/freertos/freertos_timer.hpp
+++ b/include/ot_utils/freertos/freertos_timer.hpp
@@ -18,14 +18,15 @@ class FreeRTOSTimer {
      */
     using Callback = std::function<void()>;
     FreeRTOSTimer(const char* name, Callback&& callback, uint32_t period_ms)
-        : FreeRTOSTimer(name, std::forward<Callback>(callback), true, period_ms) {}
+        : FreeRTOSTimer(name, std::forward<Callback>(callback), true,
+                        period_ms) {}
 
     FreeRTOSTimer(const char* name, Callback&& callback, bool autoreload,
                   uint32_t period_ms)
         : callback{std::move(callback)} {
-        timer = xTimerCreateStatic(name, pdMS_TO_TICKS(period_ms), 
-                                   static_cast<UBaseType_t>(autoreload),
-                                   this, timer_callback, &timer_buffer);
+        timer = xTimerCreateStatic(name, pdMS_TO_TICKS(period_ms),
+                                   static_cast<UBaseType_t>(autoreload), this,
+                                   timer_callback, &timer_buffer);
     }
 
     auto operator=(FreeRTOSTimer&) -> FreeRTOSTimer& = delete;

--- a/include/ot_utils/freertos/freertos_timer.hpp
+++ b/include/ot_utils/freertos/freertos_timer.hpp
@@ -18,12 +18,13 @@ class FreeRTOSTimer {
      */
     using Callback = std::function<void()>;
     FreeRTOSTimer(const char* name, Callback&& callback, uint32_t period_ms)
-        : FreeRTOSTimer(name, callback, true, period_ms) {}
+        : FreeRTOSTimer(name, std::forward<Callback>(callback), true, period_ms) {}
 
     FreeRTOSTimer(const char* name, Callback&& callback, bool autoreload,
                   uint32_t period_ms)
         : callback{std::move(callback)} {
-        timer = xTimerCreateStatic(name, pdMS_TO_TICKS(period_ms), autoreload,
+        timer = xTimerCreateStatic(name, pdMS_TO_TICKS(period_ms), 
+                                   static_cast<UBaseType_t>(autoreload),
                                    this, timer_callback, &timer_buffer);
     }
 
@@ -36,7 +37,7 @@ class FreeRTOSTimer {
     auto is_running() -> bool { return (xTimerIsTimerActive(timer) == pdTRUE); }
 
     void update_callback(Callback&& new_callback) {
-        callback = std::move(callback);
+        callback = std::move(new_callback);
     }
 
     void update_period(uint32_t period_ms) {
@@ -58,7 +59,7 @@ class FreeRTOSTimer {
 
     auto start_from_isr() -> bool {
         BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-        auto ret = xTimerStartFromISR(_timer, &xHigherPriorityTaskWoken);
+        auto ret = xTimerStartFromISR(timer, &xHigherPriorityTaskWoken);
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
         portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
         return ret == pdPASS;
@@ -66,7 +67,7 @@ class FreeRTOSTimer {
 
     auto stop_from_isr() -> bool {
         BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-        auto ret = xTimerStopFromISR(_timer, &xHigherPriorityTaskWoken);
+        auto ret = xTimerStopFromISR(timer, &xHigherPriorityTaskWoken);
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
         portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
         return ret == pdPASS;


### PR DESCRIPTION
Some other development caught a couple of errors with this file.

- Need to forward Callback parameter between initializers
- Linter caught that the `update_callback` function wasn't actually updating the callback
- Wrong variable name in `from_isr` functions