### PR TITLE
Upgrade the performance of the PID calcualtion with constant sampletime

### DIFF
--- a/include/ot_utils/core/pid.hpp
+++ b/include/ot_utils/core/pid.hpp
@@ -54,6 +54,7 @@ class PID {
     [[nodiscard]] auto ki() const -> double;
     [[nodiscard]] auto kd() const -> double;
     [[nodiscard]] auto sampletime() const -> double;
+    [[nodiscard]] auto sampletime_inv() const -> double;
     [[nodiscard]] auto windup_limit_high() const -> double;
     [[nodiscard]] auto windup_limit_low() const -> double;
     [[nodiscard]] auto last_error() const -> double;
@@ -66,6 +67,7 @@ class PID {
     double _ki;
     double _kd;
     double _sampletime;
+    double _sampletime_inv;
     double _windup_limit_high;
     double _windup_limit_low;
     double _last_error;

--- a/include/ot_utils/core/pid.hpp
+++ b/include/ot_utils/core/pid.hpp
@@ -67,7 +67,7 @@ class PID {
     double _ki;
     double _kd;
     double _sampletime;
-    double _sampletime_inv;
+    double _sampletime_inv = 0.0;
     double _windup_limit_high;
     double _windup_limit_low;
     double _last_error;

--- a/src/pid.cpp
+++ b/src/pid.cpp
@@ -15,6 +15,7 @@ PID::PID(double kp, double ki, double kd, double sampletime,
       _ki(ki),
       _kd(kd),
       _sampletime(sampletime),
+      _sampletime_inv(1.0 / sampletime),
       _windup_limit_high(windup_limit_high),
       _windup_limit_low(windup_limit_low),
       _last_error(0),
@@ -27,6 +28,8 @@ auto PID::ki() const -> double { return _ki; }
 auto PID::kd() const -> double { return _kd; }
 
 auto PID::sampletime() const -> double { return _sampletime; }
+
+auto PID::sampletime_inv() const -> double { return _sampletime_inv; }
 
 auto PID::last_iterm() const -> double { return _last_iterm; }
 
@@ -49,12 +52,13 @@ auto PID::compute(double error) -> double {
     const double errdiff = error - last_error();
     _last_error = error;
     const double pterm = kp() * error;
-    const double dterm = kd() * errdiff / sampletime();
+    const double dterm = kd() * errdiff * sampletime_inv();
     return pterm + iterm + dterm;
 }
 
 auto PID::compute(double error, double sampletime) -> double {
     _sampletime = sampletime;
+    _sampletime_inv = 1.0 / sampletime;
     return compute(error);
 }
 

--- a/src/pid.cpp
+++ b/src/pid.cpp
@@ -15,11 +15,14 @@ PID::PID(double kp, double ki, double kd, double sampletime,
       _ki(ki),
       _kd(kd),
       _sampletime(sampletime),
-      _sampletime_inv(1.0 / sampletime),
       _windup_limit_high(windup_limit_high),
       _windup_limit_low(windup_limit_low),
       _last_error(0),
-      _last_iterm(0) {}
+      _last_iterm(0) {
+          if (sampletime != 0) {
+              _sampletime_inv = 1.0 / sampletime;
+          } else { _sampletime_inv = 0; }
+      }
 
 auto PID::kp() const -> double { return _kp; }
 
@@ -58,7 +61,9 @@ auto PID::compute(double error) -> double {
 
 auto PID::compute(double error, double sampletime) -> double {
     _sampletime = sampletime;
-    _sampletime_inv = 1.0 / sampletime;
+    if (sampletime != 0) {
+        _sampletime_inv = 1.0 / sampletime;
+    } else { _sampletime_inv = 0;}
     return compute(error);
 }
 

--- a/src/pid.cpp
+++ b/src/pid.cpp
@@ -19,10 +19,12 @@ PID::PID(double kp, double ki, double kd, double sampletime,
       _windup_limit_low(windup_limit_low),
       _last_error(0),
       _last_iterm(0) {
-          if (sampletime != 0) {
-              _sampletime_inv = 1.0 / sampletime;
-          } else { _sampletime_inv = 0; }
-      }
+    if (sampletime != 0) {
+        _sampletime_inv = 1.0 / sampletime;
+    } else {
+        _sampletime_inv = 0;
+    }
+}
 
 auto PID::kp() const -> double { return _kp; }
 
@@ -63,7 +65,9 @@ auto PID::compute(double error, double sampletime) -> double {
     _sampletime = sampletime;
     if (sampletime != 0) {
         _sampletime_inv = 1.0 / sampletime;
-    } else { _sampletime_inv = 0;}
+    } else {
+        _sampletime_inv = 0;
+    }
     return compute(error);
 }
 


### PR DESCRIPTION
https://opentrons.atlassian.net/browse/RLAB-98

changing from doing the division every compute, to only at constructor time and using multiplication on the stm32G4 this shaved about 30% off the execution time of the compute function